### PR TITLE
Add StdRng to global state, modify routing with rng arg

### DIFF
--- a/src/main.rs
+++ b/src/main.rs
@@ -18,11 +18,12 @@ fn main() {
     use crate::model::board::Board;
     use krabmaga::engine::{schedule::Schedule, state::State};
 
+    let seed = 0;
     let step = 100;
     let num_agents = 4;
     let dim: (u16, u16) = (10, 10);
 
-    let mut board = Board::new(dim, num_agents);
+    let mut board = Board::new_with_seed(dim, num_agents, seed);
 
     // Use simulate
     // simulate!(state, step, 10, false);

--- a/src/model/board.rs
+++ b/src/model/board.rs
@@ -10,6 +10,7 @@ use krabmaga::engine::{
 use krabmaga::HashMap;
 use rand::rngs::StdRng;
 use rand::{Rng, SeedableRng};
+use std::collections::BTreeMap;
 use std::hash::{Hash, Hasher};
 use strum::IntoEnumIterator;
 
@@ -56,7 +57,7 @@ pub struct Board {
     pub dim: (u16, u16),
     pub num_agents: u8,
     pub agent_histories: HashMap<u32, History>,
-    pub resource_locations: HashMap<Resource, Vec<Int2D>>,
+    pub resource_locations: BTreeMap<Resource, Vec<Int2D>>,
     pub rng: StdRng,
 }
 
@@ -69,7 +70,7 @@ impl Board {
             dim,
             num_agents,
             agent_histories: HashMap::new(),
-            resource_locations: HashMap::new(),
+            resource_locations: BTreeMap::new(),
             rng: StdRng::from_entropy(),
         }
     }
@@ -81,7 +82,7 @@ impl Board {
             dim,
             num_agents,
             agent_histories: HashMap::new(),
-            resource_locations: HashMap::new(),
+            resource_locations: BTreeMap::new(),
             rng: StdRng::seed_from_u64(seed),
         }
     }

--- a/src/model/board.rs
+++ b/src/model/board.rs
@@ -7,8 +7,8 @@ use krabmaga::engine::{
     fields::sparse_object_grid_2d::SparseGrid2D, location::Int2D, state::State,
 };
 use krabmaga::HashMap;
-use rand::Rng;
-use serde::{Deserialize, Serialize};
+use rand::rngs::StdRng;
+use rand::{Rng, SeedableRng};
 use std::hash::{Hash, Hasher};
 
 #[derive(Clone, Copy, Debug)]
@@ -54,6 +54,7 @@ pub struct Board {
     pub dim: (u16, u16),
     pub num_agents: u8,
     pub agent_histories: HashMap<u32, History>,
+    pub rng: StdRng,
 }
 
 impl Board {
@@ -65,6 +66,18 @@ impl Board {
             dim,
             num_agents,
             agent_histories: HashMap::new(),
+            rng: StdRng::from_entropy(),
+        }
+    }
+    pub fn new_with_seed(dim: (u16, u16), num_agents: u8, seed: u64) -> Board {
+        Board {
+            step: 0,
+            agent_grid: SparseGrid2D::new(dim.0.into(), dim.0.into()),
+            resource_grid: DenseGrid2D::new(dim.0.into(), dim.1.into()),
+            dim,
+            num_agents,
+            agent_histories: HashMap::new(),
+            rng: StdRng::seed_from_u64(seed),
         }
     }
 }
@@ -72,11 +85,9 @@ impl Board {
 impl State for Board {
     fn init(&mut self, schedule: &mut krabmaga::engine::schedule::Schedule) {
         self.step = 0;
-        let mut rng = rand::thread_rng();
-
         for n in 0..self.num_agents {
-            let x: u16 = rng.gen_range(1..self.dim.0);
-            let y: u16 = rng.gen_range(1..self.dim.1);
+            let x: u16 = self.rng.gen_range(1..self.dim.0);
+            let y: u16 = self.rng.gen_range(1..self.dim.1);
 
             let id: u32 = n.into();
 

--- a/src/model/board.rs
+++ b/src/model/board.rs
@@ -10,7 +10,6 @@ use krabmaga::engine::{
 use krabmaga::HashMap;
 use rand::rngs::StdRng;
 use rand::{Rng, SeedableRng};
-use std::collections::BTreeMap;
 use std::hash::{Hash, Hasher};
 use strum::IntoEnumIterator;
 
@@ -57,7 +56,8 @@ pub struct Board {
     pub dim: (u16, u16),
     pub num_agents: u8,
     pub agent_histories: HashMap<u32, History>,
-    pub resource_locations: BTreeMap<Resource, Vec<Int2D>>,
+    // TODO: consider refactor to BTreeMap if issues occur around deterministic iteration
+    pub resource_locations: HashMap<Resource, Vec<Int2D>>,
     pub rng: StdRng,
 }
 
@@ -70,7 +70,7 @@ impl Board {
             dim,
             num_agents,
             agent_histories: HashMap::new(),
-            resource_locations: BTreeMap::new(),
+            resource_locations: HashMap::new(),
             rng: StdRng::from_entropy(),
         }
     }
@@ -82,7 +82,7 @@ impl Board {
             dim,
             num_agents,
             agent_histories: HashMap::new(),
-            resource_locations: BTreeMap::new(),
+            resource_locations: HashMap::new(),
             rng: StdRng::seed_from_u64(seed),
         }
     }
@@ -125,7 +125,7 @@ impl State for Board {
                     x: i.into(),
                     y: j.into(),
                 };
-                let item: EnvItem = rand::random();
+                let item: EnvItem = self.rng.gen();
                 let patch = Patch::new(id, item);
                 self.resource_grid.set_object_location(patch, &pos);
                 if let EnvItem::Resource(resource) = patch.env_item {

--- a/src/model/environment.rs
+++ b/src/model/environment.rs
@@ -1,4 +1,3 @@
-use rand::thread_rng;
 use rand::{
     distributions::{Distribution, Standard},
     Rng,
@@ -16,7 +15,6 @@ pub enum EnvItem {
 
 impl Distribution<EnvItem> for Standard {
     fn sample<R: Rng + ?Sized>(&self, rng: &mut R) -> EnvItem {
-        let mut rng = thread_rng();
         let pick: f32 = rng.gen();
         if pick < FOOD_ABUNDANCE {
             EnvItem::Resource(Resource::Food)

--- a/src/model/environment.rs
+++ b/src/model/environment.rs
@@ -27,7 +27,7 @@ impl Distribution<EnvItem> for Standard {
     }
 }
 
-#[derive(Debug, Clone, Copy, Hash, PartialEq, Eq, EnumIter)]
+#[derive(Debug, Clone, Copy, Hash, PartialEq, Eq, EnumIter, PartialOrd, Ord)]
 pub enum Resource {
     Food,
     Water,

--- a/src/model/forager.rs
+++ b/src/model/forager.rs
@@ -11,7 +11,6 @@ use crate::config::{
     FOOD_ACQUIRE_RATE, FOOD_CONSUME_RATE, FOOD_MAX_INVENTORY, WATER_ACQUIRE_RATE,
     WATER_CONSUME_RATE, WATER_MAX_INVENTORY,
 };
-use krabmaga::engine::fields::field_2d::Location2D;
 use krabmaga::engine::state::State;
 use krabmaga::engine::{agent::Agent, location::Int2D};
 use rand::{
@@ -187,14 +186,16 @@ impl Position for Forager {
 }
 
 impl Router for Forager {
-    fn try_move_towards(&self, resource: &Resource, state: &dyn State) -> Option<Direction> {
+    fn try_move_towards(&self, resource: &Resource, state: &mut dyn State) -> Option<Direction> {
+        // Downcast to get access to rng
+        let state = state.as_any_mut().downcast_mut::<Board>().unwrap();
         match &self.find_nearest(resource, state, None) {
             None => rand::random(),
             Some(pos) => {
                 if pos.eq(&self.get_position()) {
                     return None;
                 }
-                move_towards(&self.get_position(), &pos)
+                move_towards(&self.get_position(), pos, &mut state.rng)
             }
         }
     }

--- a/src/model/routing.rs
+++ b/src/model/routing.rs
@@ -60,7 +60,7 @@ fn step_distance(a: &Int2D, b: &Int2D) -> u32 {
 
 /// Computes the straight line distance from a to b.
 fn sight_distance(a: &Int2D, b: &Int2D) -> f32 {
-    f32::sqrt(((a.x - b.x) ^ 2 + (a.y - b.y) ^ 2) as f32)
+    f32::sqrt(((a.x - b.x).pow(2) + (a.y - b.y).pow(2)) as f32)
 }
 
 /// Decides an appropriate direction to move towards a target.
@@ -116,9 +116,16 @@ pub fn move_towards(pos: &Int2D, target: &Int2D, rng: &mut StdRng) -> Option<Dir
 
 #[cfg(test)]
 mod tests {
+    use super::*;
     use rand::SeedableRng;
 
-    use super::*;
+    #[test]
+    fn test_sight_dist() {
+        assert_eq!(
+            sight_distance(&Int2D { x: 0, y: 0 }, &Int2D { x: 4, y: 3 }),
+            5.
+        )
+    }
 
     #[test]
     fn test_move_towards() {


### PR DESCRIPTION
Closes #15.

Adds a `StdRng` to global state (`Board`) for use with any random samples drawn.